### PR TITLE
fix(cli): wrong repository in goreleaser

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -50,7 +50,7 @@ archives:
 release:
   prerelease: auto
   footer: |
-    **Full Changelog**: https://github.com/mdblist-cli/mdblist-cli/compare/{{ .PreviousTag }}...{{ .Tag }}
+    **Full Changelog**: https://github.com/luckylittle/mdblist-cli/compare/{{ .PreviousTag }}...{{ .Tag }}
 
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"


### PR DESCRIPTION
#### What is the relevant ticket/issue

* Bugfix for goreleaser

#### What’s this PR do

##### Fix

* Incorrect repository in goreleaser

#### Where should the reviewer start

* `goreleaser.yml`

#### How should this be manually tested

* Look at the releases and this time the correct `/compare/{{ .PreviousTag }}...{{ .Tag }}` link will appear

#### Risk involved

* No

#### Screenshots (if appropriate)

* No

#### Does the documentation or dependencies need an update

* No
